### PR TITLE
FEATURE: TYPO3 11.5 Support

### DIFF
--- a/Classes/Widget/Provider/AbstractTaskqueueProvider.php
+++ b/Classes/Widget/Provider/AbstractTaskqueueProvider.php
@@ -4,6 +4,7 @@ namespace Undkonsorten\Taskqueue\Widget\Provider;
 
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Dashboard\WidgetApi;
 use TYPO3\CMS\Dashboard\Widgets\ChartDataProviderInterface;
 
 abstract class AbstractTaskqueueProvider implements ChartDataProviderInterface
@@ -54,7 +55,7 @@ abstract class AbstractTaskqueueProvider implements ChartDataProviderInterface
      */
     protected function prepareChartData(): void
     {
-        parent::prepareChartData();
+        self::prepareChartData();
 
         $this->chartData = $this->getChartData();
     }
@@ -94,7 +95,7 @@ abstract class AbstractTaskqueueProvider implements ChartDataProviderInterface
             'datasets' => [
                 [
                     'label' => 'Number of tasks',
-                    'borderColor' => $this->chartColors[0],
+                    'borderColor' => WidgetApi::getDefaultChartColors()[0],
                     'fill' => false,
                     'data' => $data
                 ]

--- a/composer.json
+++ b/composer.json
@@ -34,23 +34,21 @@
     }
   ],
   "require": {
-    "ext-json": "*",
-    "php": "^7.4",
-    "typo3/cms-backend": "^11.4",
-    "typo3/cms-core": "^11.4",
-    "typo3/cms-extbase": "^11.4"
+    "typo3/cms-backend": "^11.4 || ^11.5",
+    "typo3/cms-core": "^11.4 || ^11.5",
+    "typo3/cms-extbase": "^11.4 || ^11.5"
   },
   "suggest": {
-		"typo3/cms-dashboard": "Allows more advanced logging of the application flow"
+    "typo3/cms-dashboard": "Allows more advanced logging of the application flow"
   },
   "autoload": {
     "psr-4": {
       "Undkonsorten\\Taskqueue\\": "Classes/"
     }
   },
-	"extra": {
-		"typo3/cms":{
-			"extension-key": "taskqueue"
-		}
-	}
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "taskqueue"
+    }
+  }
 }


### PR DESCRIPTION
- [x] Correct call to "self", where "parent" is not correct
- [x] Change Dashboard API for default chart colors

Can be tested by adding the following to the `repositories` section of root `composer.json`

```
        {
            "type": "git",
            "url": "git@github.com:sorenmalling/typo3-taskqueue.git"
        }
```

and then require ` "undkonsorten/taskqueue": "dev-typo3-11.5-support"`

Resolves #1 