### PR TITLE
Fix LatestTasksWidget.php for PHP^8.2

### DIFF
--- a/Classes/Widget/LatestTasksWidget.php
+++ b/Classes/Widget/LatestTasksWidget.php
@@ -60,6 +60,11 @@ class LatestTasksWidget implements WidgetInterface, RequestAwareWidgetInterface
      */
     private $dataProvider;
 
+    /**
+     * @var BackendViewFactory
+     */
+    private BackendViewFactory $backendViewFactory;
+
     public function __construct(
         WidgetConfigurationInterface $configuration,
         ListDataProviderInterface $dataProvider,


### PR DESCRIPTION
The following error is thrown when trying to access the Dashboard module in the Typo3 Backend:

```
(1/1) #1476107295 TYPO3\CMS\Core\Error\Exception

PHP Runtime Deprecation Notice: Creation of dynamic property Undkonsorten\Taskqueue\Widget\LatestTasksWidget::$backendViewFactory is deprecated in /var/www/html/vendor/undkonsorten/taskqueue/Classes/Widget/LatestTasksWidget.php line 71
```

This seems to be a deprecation introduced in PHP 8.2, so it does not work anymore in following PHP versions.

Adding the BackendViewFactory property fixes this issue.

PHP version: 8.3
Extension version: 9.4.1
Typo3 version: 13.4.18